### PR TITLE
BlocksReduced.txt as input of generate-symbols.py instead of the full Blocks.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ Blocks.txt:
 BlocksReduced.txt: Blocks.txt Blocks.patch
 	cp Blocks.txt $@
 	patch --merge $@ -p1 < Blocks.patch
-	rm *.orig
+	rm -f *.orig
 
 symbols: BlocksReduced.txt
-	./generate-symbols.py > "$@"
+	./generate-symbols.py $< > "$@"
 
 install: symbols
 	install -d -m755 $(PREFIX)/bin

--- a/generate-symbols.py
+++ b/generate-symbols.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
+import sys
 import unicodedata
 
 ranges = []
-with open("Blocks.txt", "r") as f:
+with open(sys.argv[1], "r") as f:
     for line in f:
         if line.startswith("#") or len(line) <= 1:
             continue


### PR DESCRIPTION
this was causing a huge `symbols` file