### PR TITLE
two enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Running with `fzf`:
 
 ![Running with fzf](http://i.imgur.com/Q6bSd0S.png)
 
+Running with `fzf` (version => 0.53) in `tmux` :
+
+![Running with fzf](https://i.imgur.com/Yx57eRz.png)
+  
+
+![Running with fzf](https://i.imgur.com/H0OOwz0.mp4)
+
 Running with `rofi -dmenu`:
 
 ![Running with rofi](http://i.imgur.com/q1eE3vA.png)
@@ -36,6 +43,25 @@ xclip can be installed in various linux distros:
 - Arch Linux: `pacman -S xclip`
 
 The `pbcopy` utility will be used on a Mac, which is installed by default.
+
+If the `fzf` version is greater than 0.53, it will use the `--tmux` switch by 
+default. If not run in tmux, it will have no effect. Uses `awk` and `bc` to 
+calculate the `fzf` version; if they are not present, it will silently assume 
+the version to be < 0.53 .
+
+If you wish to bind it to a key in tmux to invoke as in the video above, use the following:
+
+```
+unbind e
+bind e if-shell -b '/path/to/unipicker' "send-keys ''"
+```
+
+If you want to add command-line arguments, do it like so:
+
+```
+unbind e
+bind e if-shell -b '/path/to/unipicker --copy-command /path/to/copycommand' "send-keys ''"
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,7 @@ Running with `fzf`:
 
 Running with `fzf` (version => 0.53) in `tmux` :
 
-![Running with fzf](https://i.imgur.com/Yx57eRz.png)
-  
-
-![Running with fzf](https://i.imgur.com/H0OOwz0.mp4)
+![Running with fzf](https://i.imgur.com/T3Lu9VF.gif)
 
 Running with `rofi -dmenu`:
 

--- a/unipicker
+++ b/unipicker
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# should be transparent if installed per the documentation, but if you just 
+# symlink from the source directory, then it'll work from there too. 
+SCRIPTDIR="$(dirname $(readlink -f "$0"))"
 should_copy=false
 
 if [ -f /etc/unipickerrc ]; then
@@ -17,8 +20,25 @@ case "$OSTYPE" in
   *)       os_copy_command="xclip -selection clipboard";;
 esac
 
-symbols_file="${UNIPICKER_SYMBOLS_FILE:-${PWD}/symbols}"
-select_command=${UNIPICKER_SELECT_COMMAND:-fzf}
+
+# because the select command only takes one positional argument, defaulting to --tmux for
+# fzf if the version is > 0.53.0. If not in a tmux session, no effect.
+if [ -f $(which bc) ] && [ -f $(which awk) ];then 
+    # not adding an official dependency, so will fallback silently; 
+    t_version=$(fzf --version | awk '{print $1}')
+    result=$(echo "$t_version > 0.53" | bc)
+else
+    result=0
+fi
+
+if [ $result -eq 1 ]; then
+    select_command=${UNIPICKER_SELECT_COMMAND:-fzf --tmux}
+else
+    select_command=${UNIPICKER_SELECT_COMMAND:-fzf}
+fi
+
+symbols_file="${UNIPICKER_SYMBOLS_FILE:-${SCRIPTDIR}/symbols}"
+select_command=${UNIPICKER_SELECT_COMMAND:-fzf --tmux}
 copy_command=${UNIPICKER_COPY_COMMAND:-${os_copy_command}}
 
 usage () {

--- a/unipicker
+++ b/unipicker
@@ -38,7 +38,7 @@ else
 fi
 
 symbols_file="${UNIPICKER_SYMBOLS_FILE:-${SCRIPTDIR}/symbols}"
-select_command=${UNIPICKER_SELECT_COMMAND:-fzf --tmux}
+#select_command=${UNIPICKER_SELECT_COMMAND:-fzf --tmux}
 copy_command=${UNIPICKER_COPY_COMMAND:-${os_copy_command}}
 
 usage () {


### PR DESCRIPTION
Uses the --tmux flag from fzf if the fzf version > 0.53 (uses awk and bc to check that, and if those aren't present, silently assumes fzf is a lower version, which it still is on Debian Bookworm)

Changed checking logic for determining script location so that you can just symlink it from the source directory to, say, $HOME/.local/bin and just work out of the box (because of the way it checks for the symbols file)