### PR TITLE
feat: allow copying emoji passed as cli argument

### DIFF
--- a/unipicker
+++ b/unipicker
@@ -39,6 +39,17 @@ usage () {
   echo "  UNIPICKER_SYMBOLS_FILE    Location of symbols (= $symbols_file)"
 }
 
+copy_emoji () {
+    if ! [ -v letter ]; then
+        letter=$(cat "$symbols_file" | eval $select_command | sed -E 's/^(.).*/\1/g')
+    fi
+
+    echo "$letter"
+    if [ "$should_copy" = true ];then
+      echo -n "$letter" | $copy_command
+    fi
+}
+
 while [ -n "$1" ];do
   case "$1" in
     --command)
@@ -63,15 +74,11 @@ while [ -n "$1" ];do
       usage
       exit;;
     *)
-      echo "Invalid argument: $1"
-      exit 1;;
+      letter=$(cat "$symbols_file" | eval $select_command --filter=$1 | head -n 1 | sed -E 's/^(.).*/\1/g')
+      copy_emoji
+      exit 0;;
   esac
   shift
 done
 
-letter=$(cat "$symbols_file" | eval $select_command | sed -E 's/^(.).*/\1/g')
-
-echo "$letter"
-if [ "$should_copy" = true ];then
-  echo -n "$letter" | $copy_command
-fi
+copy_emoji

--- a/unipicker
+++ b/unipicker
@@ -24,7 +24,7 @@ copy_command=${UNIPICKER_COPY_COMMAND:-${os_copy_command}}
 usage () {
   echo "Select unicode character by description"
   echo ""
-  echo "Usage: unipicker [--command cmd] [--copy-command cmd ] [--copy] [--list]"
+  echo "Usage: unipicker [--command cmd] [--copy-command cmd ] [--copy] [--list] [emoji_name]"
   echo ""
   echo "Arguments:"
   echo "  --command       Overrides default select command"


### PR DESCRIPTION
This PR allows the user to copy an emoji directly by passing the emoji's name as a CLI argument, like so:

`Usage: unipicker [--command cmd] [--copy-command cmd ] [--copy] [--list] [emoji_name]`